### PR TITLE
[ubuntu] Don't install documentation for ruby gems

### DIFF
--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -20,7 +20,7 @@ gems_to_install=$(get_toolset_value ".rubygems[] .name")
 if [[ -n "$gems_to_install" ]]; then
     for gem in $gems_to_install; do
         echo "Installing gem $gem"
-        gem install $gem
+        gem install --no-document $gem
     done
 fi
 


### PR DESCRIPTION
# Description
Improvement: Don't install rdoc/ri (ruby information) documentation in the runner image.

Just something I randomly noticed in the output of building an image, and it's not needed since the documentation isn't for programmatic access.

## Check list
- [n/a] Related issue / work item is attached
- [n/a] Tests are written (if applicable)
- [n/a] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

Changed worked locally for me, and sped up the ruby install step from ~135 seconds to ~60 seconds (55% speed up).
